### PR TITLE
Various small fixes in bareos formula

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,6 @@ driver:
 
 platforms:
   - name: bento/debian-8
-  - name: bento/debian-9
   - name: bento/ubuntu-16.04
   - name: bento/centos-6
   - name: bento/centos-7

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,12 +38,8 @@ suites:
         - name: postgres
           repo: git
           source: https://github.com/saltstack-formulas/postgres-formula.git
-      pillars:
-        bareos.sls:
-          bareos:
-            director:
-              database:
-                backend: postgresql
+      pillars-from-files:
+        bareos.sls: test/integration/bareos-postgresql/bareos-postgresql.pillar.yaml
       state_top:
         base:
           '*':

--- a/bareos/bconsole.sls
+++ b/bareos/bconsole.sls
@@ -28,7 +28,7 @@ bareos_bconsole_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 750
+    - mode: 640
     - user: {{ bareos.system_user }}
     - group: {{ bareos.system_group }}
     - require:

--- a/bareos/bconsole.sls
+++ b/bareos/bconsole.sls
@@ -24,7 +24,7 @@ bareos_bconsole_cfg_file:
     - name: {{ bareos.config_dir }}/{{ bareos.bconsole.config_file }}
     - source: salt://bareos/files/bareos-config.jinja
     - context:
-        config: {{ bc_config|json() }}
+        config: {{ bc_config|yaml() }}
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja

--- a/bareos/bconsole.sls
+++ b/bareos/bconsole.sls
@@ -28,9 +28,9 @@ bareos_bconsole_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 644
-    - user: root
-    - group: root
+    - mode: 750
+    - user: {{ bareos.system_user }}
+    - user: {{ bareos.system_group }}
     - require:
       - pkg: install_bconsole_package
 {% endif %}

--- a/bareos/bconsole.sls
+++ b/bareos/bconsole.sls
@@ -30,7 +30,7 @@ bareos_bconsole_cfg_file:
     - template: jinja
     - mode: 750
     - user: {{ bareos.system_user }}
-    - user: {{ bareos.system_group }}
+    - group: {{ bareos.system_group }}
     - require:
       - pkg: install_bconsole_package
 {% endif %}

--- a/bareos/defaults.yaml
+++ b/bareos/defaults.yaml
@@ -4,6 +4,8 @@ bareos:
   version: 16.2.4-12.1
   config_dir: /etc/bareos
   default_password: default_bareos_formula_password
+  system_user: bareos
+  system_group: bareos
 
   use_upstream_repo: true
   # One of http://download.bareos.org/bareos/release/

--- a/bareos/defaults.yaml
+++ b/bareos/defaults.yaml
@@ -20,6 +20,7 @@ bareos:
 
   director:
     pkg: bareos-director
+    config_dir: bareos-dir.d
     config_file: bareos-dir.conf
     plugins: []
     service: bareos-dir
@@ -33,14 +34,16 @@ bareos:
 
   storage:
     pkg: bareos-storage
-    backends: []
+    config_dir: bareos-sd.d
     config_file: bareos-sd.conf
+    backends: []
     service: bareos-sd
 
   filedaemon:
     pkg: bareos-filedaemon
-    plugins: []
+    config_dir: bareos-fd.d
     config_file: bareos-fd.conf
+    plugins: []
     service: bareos-fd
 
   client:
@@ -48,7 +51,9 @@ bareos:
 
   traymonitor:
     pkg: bareos-traymonitor
+    config_dir: tray-monitor.d
     config_file: tray-monitor.conf
 
   bconsole:
     pkg: bareos-bconsole
+    config_file: bconsole.conf

--- a/bareos/director.sls
+++ b/bareos/director.sls
@@ -29,6 +29,7 @@ install_director_plugins:
       - pkgrepo: bareos_repo
     {% endif %}
 
+{% if dir_config != {} %}
 cleanup_director_default_config:
   file.directory:
     - name: {{ bareos.config_dir }}/{{ bareos.director.config_dir }}
@@ -46,7 +47,6 @@ create_director_dir:
     - user: {{ bareos.system_user }}
     - group: {{ bareos.system_group }}
 
-{% if dir_config != {} %}
 bareos_director_cfg_file:
   file.managed:
     - name: {{ bareos.config_dir }}/{{ bareos.director.config_dir }}/director/{{ bareos.director.config_file }}
@@ -56,7 +56,7 @@ bareos_director_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 750
+    - mode: 640
     - user: {{ bareos.system_user }}
     - group: {{ bareos.system_group }}
     - require:

--- a/bareos/director.sls
+++ b/bareos/director.sls
@@ -34,7 +34,7 @@ cleanup_director_default_config:
     - name: {{ bareos.config_dir }}/{{ bareos.director.config_dir }}
     - mode: 750
     - user: {{ bareos.system_user }}
-    - user: {{ bareos.system_group }}
+    - group: {{ bareos.system_group }}
     - clean: true
     - onchanges:
       - pkg: bareos-director
@@ -44,7 +44,7 @@ create_director_dir:
     - name: {{ bareos.config_dir }}/{{ bareos.director.config_dir }}/director
     - mode: 750
     - user: {{ bareos.system_user }}
-    - user: {{ bareos.system_group }}
+    - group: {{ bareos.system_group }}
 
 {% if dir_config != {} %}
 bareos_director_cfg_file:
@@ -58,7 +58,7 @@ bareos_director_cfg_file:
     - template: jinja
     - mode: 750
     - user: {{ bareos.system_user }}
-    - user: {{ bareos.system_group }}
+    - group: {{ bareos.system_group }}
     - require:
       - pkg: bareos-director
     - watch_in:

--- a/bareos/director.sls
+++ b/bareos/director.sls
@@ -39,9 +39,9 @@ bareos_director_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 644
-    - user: root
-    - group: root
+    - mode: 750
+    - user: {{ bareos.system_user }}
+    - user: {{ bareos.system_group }}
     - require:
       - pkg: bareos-director
     - watch_in:

--- a/bareos/director.sls
+++ b/bareos/director.sls
@@ -29,10 +29,27 @@ install_director_plugins:
       - pkgrepo: bareos_repo
     {% endif %}
 
+cleanup_director_default_config:
+  file.directory:
+    - name: {{ bareos.config_dir }}/{{ bareos.director.config_dir }}
+    - mode: 750
+    - user: {{ bareos.system_user }}
+    - user: {{ bareos.system_group }}
+    - clean: true
+    - onchanges:
+      - pkg: bareos-director
+
+create_director_dir:
+  file.directory:
+    - name: {{ bareos.config_dir }}/{{ bareos.director.config_dir }}/director
+    - mode: 750
+    - user: {{ bareos.system_user }}
+    - user: {{ bareos.system_group }}
+
 {% if dir_config != {} %}
 bareos_director_cfg_file:
   file.managed:
-    - name: {{ bareos.config_dir }}/{{ bareos.director.config_file }}
+    - name: {{ bareos.config_dir }}/{{ bareos.director.config_dir }}/director/{{ bareos.director.config_file }}
     - source: salt://bareos/files/bareos-config.jinja
     - context:
         config: {{ dir_config|yaml() }}

--- a/bareos/director.sls
+++ b/bareos/director.sls
@@ -35,7 +35,7 @@ bareos_director_cfg_file:
     - name: {{ bareos.config_dir }}/{{ bareos.director.config_file }}
     - source: salt://bareos/files/bareos-config.jinja
     - context:
-        config: {{ dir_config|json() }}
+        config: {{ dir_config|yaml() }}
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja

--- a/bareos/filedaemon.sls
+++ b/bareos/filedaemon.sls
@@ -36,9 +36,9 @@ bareos_fd_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 644
-    - user: root
-    - group: root
+    - mode: 750
+    - user: {{ bareos.system_user }}
+    - user: {{ bareos.system_group }}
     - require:
       - pkg: install_fd_package
     - watch_in:

--- a/bareos/filedaemon.sls
+++ b/bareos/filedaemon.sls
@@ -44,7 +44,7 @@ bareos_fd_cfg_file:
     - template: jinja
     - mode: 750
     - user: {{ bareos.system_user }}
-    - user: {{ bareos.system_group }}
+    - group: {{ bareos.system_group }}
     - require:
       - pkg: install_fd_package
     - watch_in:

--- a/bareos/filedaemon.sls
+++ b/bareos/filedaemon.sls
@@ -26,13 +26,13 @@ install_fd_plugins:
       - pkgrepo: bareos_repo
     {% endif %}
 
+{% if fd_config != {} %}
 cleanup_fd_default_config:
   file.absent:
     - name: {{ bareos.config_dir }}/{{ bareos.filedaemon.config_dir }}
     - onchanges:
       - pkg: install_fd_package
 
-{% if fd_config != {} %}
 bareos_fd_cfg_file:
   file.managed:
     - name: {{ bareos.config_dir }}/{{ bareos.filedaemon.config_file }}
@@ -42,7 +42,7 @@ bareos_fd_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 750
+    - mode: 640
     - user: {{ bareos.system_user }}
     - group: {{ bareos.system_group }}
     - require:

--- a/bareos/filedaemon.sls
+++ b/bareos/filedaemon.sls
@@ -32,7 +32,7 @@ bareos_fd_cfg_file:
     - name: {{ bareos.config_dir }}/{{ bareos.filedaemon.config_file }}
     - source: salt://bareos/files/bareos-config.jinja
     - context:
-        config: {{ fd_config|json() }}
+        config: {{ fd_config|yaml() }}
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja

--- a/bareos/filedaemon.sls
+++ b/bareos/filedaemon.sls
@@ -26,6 +26,12 @@ install_fd_plugins:
       - pkgrepo: bareos_repo
     {% endif %}
 
+cleanup_fd_default_config:
+  file.absent:
+    - name: {{ bareos.config_dir }}/{{ bareos.filedaemon.config_dir }}
+    - onchanges:
+      - pkg: install_fd_package
+
 {% if fd_config != {} %}
 bareos_fd_cfg_file:
   file.managed:

--- a/bareos/files/bareos-config.jinja
+++ b/bareos/files/bareos-config.jinja
@@ -34,10 +34,10 @@
     {% else %}
         {%- for name, config in resources.iteritems() %}
 {{ type }} {
-            {% if (type|lower) in requires_name and 'name' not in (config|lower) %}
+            {%- if (type|lower) in requires_name and ( (config.name is not defined) and (config.Name is not defined) )  %}
     Name = "{{ name }}"
             {%- endif %}
-            {%- if (type|lower) in require_password and 'password' not in (config|lower) %}
+            {%- if (type|lower) in require_password and ( (config.password is not defined) and (config.Password is not defined) )  %}
     Password = "{{ default_password }}"
             {%- endif %}
     {{ _config(config) }}

--- a/bareos/files/bareos-config.jinja
+++ b/bareos/files/bareos-config.jinja
@@ -34,10 +34,11 @@
     {% else %}
         {%- for name, config in resources.iteritems() %}
 {{ type }} {
-            {% if type|lower in requires_name and 'name' not in config|lower %}
+            {%- if type|lower in requires_name and "Name" not in config %}
+
     Name = "{{ name }}"
             {%- endif %}
-             {%- if type|lower in require_password and 'password' not in config|lower %}
+             {%- if type|lower in require_password and "Password" not in config %}
     Password = "{{ default_password }}"
              {%- endif %}
     {{ _config(config) }}

--- a/bareos/files/bareos-config.jinja
+++ b/bareos/files/bareos-config.jinja
@@ -34,13 +34,12 @@
     {% else %}
         {%- for name, config in resources.iteritems() %}
 {{ type }} {
-            {%- if type|lower in requires_name and "Name" not in config %}
-
+            {% if (type|lower) in requires_name and 'name' not in (config|lower) %}
     Name = "{{ name }}"
             {%- endif %}
-             {%- if type|lower in require_password and "Password" not in config %}
+            {%- if (type|lower) in require_password and 'password' not in (config|lower) %}
     Password = "{{ default_password }}"
-             {%- endif %}
+            {%- endif %}
     {{ _config(config) }}
 }
         {%- endfor %}

--- a/bareos/map.jinja
+++ b/bareos/map.jinja
@@ -6,7 +6,7 @@
    merge=salt['grains.filter_by'](
          osfamilymap,
          grain='os_family',
-         merge=salt['grains.get']('bareos', {}),
+         merge=salt['pillar.get']('bareos', {}),
    ),
    base='bareos',
 ) %}

--- a/bareos/repo.sls
+++ b/bareos/repo.sls
@@ -10,7 +10,7 @@
   {% set distro = grains.os ~ '_' ~ grains.osmajorrelease %}
 {%- endif %}
 
-{% if salt['grains.get']('os_family') == 'Debian' -%}
+{% if grains.os_family == 'Debian' -%}
 bareos_repo:
   pkgrepo.managed:
     - humanname: {{ bareos.repo.humanname }} - {{ bareos.repo.version }}
@@ -19,7 +19,7 @@ bareos_repo:
     - keyid: {{ bareos.repo.keyid }}
     - keyserver: {{ bareos.repo.keyserver }}
 
-{%- elif salt['grains.get']('os_family') == 'RedHat' %}
+{%- elif grains.os_family == 'RedHat' %}
 bareos_repo:
   pkgrepo.managed:
     - name: bareos

--- a/bareos/storage.sls
+++ b/bareos/storage.sls
@@ -36,9 +36,9 @@ bareos_storage_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 644
-    - user: root
-    - group: root
+    - mode: 750
+    - user: {{ bareos.system_user }}
+    - user: {{ bareos.system_group }}
     - require:
       - pkg: install_storage_package
     - watch_in:

--- a/bareos/storage.sls
+++ b/bareos/storage.sls
@@ -26,13 +26,13 @@ install_storage_plugins:
       - pkgrepo: bareos_repo
     {% endif %}
 
+{% if sd_config != {} %}
 cleanup_storage_default_config:
   file.absent:
     - name: {{ bareos.config_dir }}/{{ bareos.storage.config_dir }}
     - onchanges:
       - pkg: install_storage_package
 
-{% if sd_config != {} %}
 bareos_storage_cfg_file:
   file.managed:
     - name: {{ bareos.config_dir }}/{{ bareos.storage.config_file }}
@@ -42,7 +42,7 @@ bareos_storage_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 750
+    - mode: 640
     - user: {{ bareos.system_user }}
     - group: {{ bareos.system_group }}
     - require:

--- a/bareos/storage.sls
+++ b/bareos/storage.sls
@@ -44,7 +44,7 @@ bareos_storage_cfg_file:
     - template: jinja
     - mode: 750
     - user: {{ bareos.system_user }}
-    - user: {{ bareos.system_group }}
+    - group: {{ bareos.system_group }}
     - require:
       - pkg: install_storage_package
     - watch_in:

--- a/bareos/storage.sls
+++ b/bareos/storage.sls
@@ -26,6 +26,12 @@ install_storage_plugins:
       - pkgrepo: bareos_repo
     {% endif %}
 
+cleanup_storage_default_config:
+  file.absent:
+    - name: {{ bareos.config_dir }}/{{ bareos.storage.config_dir }}
+    - onchanges:
+      - pkg: install_storage_package
+
 {% if sd_config != {} %}
 bareos_storage_cfg_file:
   file.managed:

--- a/bareos/storage.sls
+++ b/bareos/storage.sls
@@ -32,7 +32,7 @@ bareos_storage_cfg_file:
     - name: {{ bareos.config_dir }}/{{ bareos.storage.config_file }}
     - source: salt://bareos/files/bareos-config.jinja
     - context:
-        config: {{ sd_config|json() }}
+        config: {{ sd_config|yaml() }}
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja

--- a/bareos/traymonitor.sls
+++ b/bareos/traymonitor.sls
@@ -18,13 +18,14 @@ install_traymon_package:
       - pkgrepo: bareos_repo
     {% endif %}
 
+
+{% if tm_config != {} %}
 cleanup_traymon_default_config:
   file.absent:
     - name: {{ bareos.config_dir }}/{{ bareos.traymonitor.config_dir }}
     - onchanges:
       - pkg: install_traymon_package
 
-{% if tm_config != {} %}
 bareos_traymon_cfg_file:
   file.managed:
     - name: {{ bareos.config_dir }}/{{ bareos.traymonitor.config_file }}
@@ -34,7 +35,7 @@ bareos_traymon_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 750
+    - mode: 640
     - user: {{ bareos.system_user }}
     - group: {{ bareos.system_group }}
     - require:

--- a/bareos/traymonitor.sls
+++ b/bareos/traymonitor.sls
@@ -36,7 +36,7 @@ bareos_traymon_cfg_file:
     - template: jinja
     - mode: 750
     - user: {{ bareos.system_user }}
-    - user: {{ bareos.system_group }}
+    - group: {{ bareos.system_group }}
     - require:
       - pkg: install_traymon_package
 {% endif %}

--- a/bareos/traymonitor.sls
+++ b/bareos/traymonitor.sls
@@ -28,9 +28,9 @@ bareos_traymon_cfg_file:
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja
-    - mode: 644
-    - user: root
-    - group: root
+    - mode: 750
+    - user: {{ bareos.system_user }}
+    - user: {{ bareos.system_group }}
     - require:
       - pkg: install_traymon_package
 {% endif %}

--- a/bareos/traymonitor.sls
+++ b/bareos/traymonitor.sls
@@ -18,6 +18,12 @@ install_traymon_package:
       - pkgrepo: bareos_repo
     {% endif %}
 
+cleanup_traymon_default_config:
+  file.absent:
+    - name: {{ bareos.config_dir }}/{{ bareos.traymonitor.config_dir }}
+    - onchanges:
+      - pkg: install_traymon_package
+
 {% if tm_config != {} %}
 bareos_traymon_cfg_file:
   file.managed:

--- a/bareos/traymonitor.sls
+++ b/bareos/traymonitor.sls
@@ -24,7 +24,7 @@ bareos_traymon_cfg_file:
     - name: {{ bareos.config_dir }}/{{ bareos.traymonitor.config_file }}
     - source: salt://bareos/files/bareos-config.jinja
     - context:
-        config: {{ tm_config|json() }}
+        config: {{ tm_config|yaml() }}
         default_password: {{ bareos.default_password }}
         require_password: {{ require_password }}
     - template: jinja

--- a/test/integration/bareos-postgresql/bareos-postgresql.pillar.yaml
+++ b/test/integration/bareos-postgresql/bareos-postgresql.pillar.yaml
@@ -1,0 +1,270 @@
+bareos:
+  use_upstream_repo: true
+  director:
+    database:
+      manage: true
+      backend: postgresql
+    config:
+      Catalog:
+        MyCatalog:
+          DbDriver: postgresql
+          DbName: bareos
+          DbUser: bareos
+          MultipleConnections: false
+
+      Client:
+        bareos-fd:
+          Address: localhost
+          Description: Client resource of the Director itself.
+          Password: 'PL5_Ch4ng3_M3!'
+
+      Console:
+        bareos-mon:
+          Command ACL: 'status, .status'
+          Description: Restricted console used by tray-monitor to get the status of the director.
+          Job ACL: '*all*'
+          Password: 'PL5_Ch4ng3_M3!'
+
+      Director:
+        bareos-dir:
+          Auditing: 'Yes'
+          MaximumConcurrentJobs: 10
+          Messages: Daemon
+          Password: 'PL5_Ch4ng3_M3!'
+          QueryFile: '/usr/lib/bareos/scripts/query.sql'
+
+      FileSet:
+        Catalog:
+          Description: "Backup the catalog dump and Bareos configuration files."
+          Include:
+            Options:
+              Signature: MD5
+
+            File:
+              - /var/lib/bareos/bareos.sql
+              - /etc/bareos
+
+        LinuxAll:
+          Description: "Backup all regular filesystems, determined by filesystem type."
+          Include:
+            Options:
+              Signature: MD5
+              OneFS: 'No'
+              FsType:
+                - btrfs
+                - ext2
+                - ext3
+                - ext4
+                - reiserfs
+                - jfs
+                - xfs
+                - zfs
+
+            File: /
+
+          Exclude:
+            File:
+              - /var/lib/bareos
+              - /var/lib/bareos/storage
+              - /proc
+              - /tmp
+              - /var/tmp
+              - /.journal
+              - /.fsck
+
+        SelfTest:
+          Description: "fileset just to backup some files for selftest"
+          Include:
+            Options:
+              Signature: MD5
+
+            File: /usr/sbin
+
+      Job:
+        backup-bareos-fd:
+          JobDefs: "DefaultJob"
+          Client: "bareos-fd"
+
+        BackupCatalog:
+          Description: "Backup the catalog database (after the nightly save)"
+          JobDefs: "DefaultJob"
+          Level: Full
+          FileSet: "Catalog"
+          Schedule: "WeeklyCycleAfterBackup"
+
+          RunBeforeJob: "/usr/lib/bareos/scripts/make_catalog_backup.pl MyCatalog"
+          RunAfterJob : "/usr/lib/bareos/scripts/delete_catalog_backup"
+
+          Write Bootstrap: "|/usr/bin/bsmtp -h localhost -f \"\\(Bareos\\) \" -s \"Bootstrap for Job %j\" root@localhost"
+          Priority: 11
+
+        RestoreFiles:
+          Description: "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+          Type: Restore
+          Client: bareos-fd
+          FileSet: "LinuxAll"
+          Storage: File
+          Pool: Incremental
+          Messages: Standard
+          Where: /tmp/bareos-restores
+
+      JobDefs:
+        DefaultJob:
+          Type: Backup
+          Level: Incremental
+          Client: bareos-fd
+          FileSet: "SelfTest"
+          Schedule: "WeeklyCycle"
+          Storage: File
+          Messages: Standard
+          Pool: Incremental
+          Priority: 10
+          Write Bootstrap: "/var/lib/bareos/%c.bsr"
+          Full Backup Pool: Full
+          Differential Backup Pool: Differential
+          Incremental Backup Pool: Incremental
+
+      Messages:
+        Daemon:
+          Description: "Message delivery for daemon messages (no job)."
+          mailcommand: "change me"
+          mail: 'root@localhost = all, !skipped, !audit'
+          console: all, !skipped, !saved, !audit
+          append:
+            - '"/var/log/bareos/bareos.log" = all, !skipped, !audit'
+            - '"/var/log/bareos/bareos-audit.log" = audit'
+        Standard:
+          Description: "Reasonable message delivery -- send most everything to email address and to the console."
+          operatorcommand: "change me"
+          mailcommand: "change me"
+          operator: 'root@localhost = mount'
+          mail: 'root@localhost = all, !skipped, !saved, !audit'
+          console: all, !skipped, !saved, !audit
+          append: '"/var/log/bareos/bareos.log" = all, !skipped, !saved, !audit'
+          catalog: 'all, !skipped, !saved, !audit'
+
+      Pool:
+        Differential:
+          Pool Type: Backup
+          Recycle: 'Yes'                     # Bareos can automatically recycle Volumes
+          AutoPrune: 'Yes'                   # Prune expired volumes
+          Volume Retention: 90 days          # How long should the Differential Backups be kept? (#09)
+          Maximum Volume Bytes: 10G          # Limit Volume size to something reasonable
+          Maximum Volumes: 100               # Limit number of Volumes in Pool
+          Label Format: "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+        Full:
+          Pool Type: Backup
+          Recycle: 'Yes'                     # Bareos can automatically recycle Volumes
+          AutoPrune: 'Yes'                   # Prune expired volumes
+          Volume Retention: 365 days         # How long should the Full Backups be kept? (#06)
+          Maximum Volume Bytes: 50G          # Limit Volume size to something reasonable
+          Maximum Volumes: 100               # Limit number of Volumes in Pool
+          Label Format: "Full-"              # Volumes will be labeled "Full-<volume-id>"
+        Incremental:
+          Pool Type: Backup
+          Recycle: 'Yes'                     # Bareos can automatically recycle Volumes
+          AutoPrune: 'Yes'                   # Prune expired volumes
+          Volume Retention: 30 days          # How long should the Incremental Backups be kept?  (#12)
+          Maximum Volume Bytes: 1G           # Limit Volume size to something reasonable
+          Maximum Volumes: 100               # Limit number of Volumes in Pool
+          Label Format: "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+        Scratch:
+          Pool Type: Scratch
+
+      Profile:
+        operator:
+          Description: Profile allowing falsermal Bareos operations.
+          Job ACL: '*all*'
+          Client ACL: '*all*'
+          Storage ACL: '*all*'
+          Schedule ACL: '*all*'
+          Pool ACL: '*all*'
+          Command ACL:
+            - '!.bvfs_clear_cache, !.exit, !.sql'
+            - '!configure, !create, !delete, !purge, !sqlquery, !umount, !unmount'
+            - '*all*'
+          FileSet ACL: '*all*'
+          Catalog ACL: '*all*'
+          Where ACL: '*all*'
+          Plugin Options ACL: '*all*'
+
+      Schedule:
+        WeeklyCycleAfterBackup:
+          Description: This schedule does the catalog. It starts after the WeeklyCycle.
+          Run:
+            - 'Full Mon-Fri at 21:10'
+
+        WeeklyCycle:
+          Run:
+            - 'Full 1st Sat at 21:00'
+            - 'Differential 2nd-5th Sat at 21:00'
+            - 'Incremental Mon-Fri at 21:00'
+
+      Storage:
+        File:
+          Address: localhost
+          Password: 'PL5_Ch4ng3_M3!'
+          Device: FileStorage
+          Media Type: File
+  filedaemon:
+    config:
+      Director:
+        bareos-dir:
+          Description: The default BareOS director resource
+          Password: 'PL5_Ch4ng3_M3!'
+      Client:
+        bareos-fd:
+          MaximumConcurrentJobs: 20
+      Messages:
+        Standard:
+          Director: bareos-debian-jessie64-dir = all, !skipped, !restored
+  storage:
+    config:
+      Director:
+        bareos-dir:
+          Description: Director, who is permitted to contact this storage daemon.
+          Password: 'PL5_Ch4ng3_M3!'
+          Monitor: false
+          MaximumBandwidthPerJob: 0
+
+      Storage:
+        bareos-sd:
+          MaximumConcurrentJobs: 20
+          MaximumNetworkBufferSize: 0
+          MaximumBandwidthPerJob: 0
+          AbsoluteJobTimeout: 0
+
+      Device:
+        FileStorage:
+          Description: File device. A connecting Director must have the same Name and MediaType.
+          MediaType: File
+          ArchiveDevice: /var/lib/bareos/storage
+          RemovableMedia: false
+          RandomAccess: true
+          AutomaticMount: true
+          LabelMedia: true
+          AlwaysOpen: false
+          MaximumNetworkBufferSize: 0
+          MinimumBlockSize: 0
+          MaximumVolumeSize: 0
+          VolumeCapacity: 0
+          MaximumConcurrentJobs: 0
+          MaximumSpoolSize: 0
+          MaximumJobSpoolSize: 0
+          DriveIndex: 0
+          MaximumPartSize: 0
+          LabelType: bareos
+          DriveTapeAlertEnabled: false
+          DriveCryptoEnabled: false
+          QueryCryptoStatus: false
+
+      Messages:
+        Standard:
+          director: bareos-dir = all
+  bconsole:
+    config:
+      Director:
+        bareos-dir:
+          DirPort: 9101
+          Address: localhost
+          Password: 'PL5_Ch4ng3_M3!'


### PR DESCRIPTION
 Use pillar file instead of populating the kitchen.yml
   
    This change is necessary because:
    * It's easier and cleaner to have pillar data in a separate file

    The issue is resolved in this commit by:
    * Adding a new pillar file

Clean up default configuration from all services

    This change is necessary because:
    * Bareos 16.x comes with a new configuration structure,
    they introduced several directories and split the configuration into different files.
    As we would like to have a central config file for every service,
    it's good to clean up the default config and structure.

    The issue is resolved in this commit by:
    * When we install a new package, we automatically clean up those directories.

Fixed jinja template IF statements

    This change is necessary as the template wasn't adding
    the name & password <key:value> elements when the config object  
    had a <key> that partially contains those strings.

    Example
    -------
    yaml object

    director:
      config:
        Catalog:
          MyCatalog:
            DbName: bareos

    The 'Name = MyCatalog' was missing from the generated config 
    as the object has DbName <key>

 Change the object format that we pass to Jinja template

    As pillar is in yaml format, it's better to pass the same format to Jinja template

Fix map.jinja file

    Merge the file contents with pillar data

Clean up repo.sls code

    Use the same syntax when calling grains

Security hardening

    Change file permissions and owner/group

Remove Debian-9 as supported platform