### PR TITLE
[bareos] add require_in to generate_password

### DIFF
--- a/bareos/bconsole.sls
+++ b/bareos/bconsole.sls
@@ -18,6 +18,10 @@ install_bconsole_package:
     - require:
       - pkgrepo: bareos_repo
     {% endif %}
+    {% if salt['pillar.get']('bareos:generate_unique_password', False) %}
+    - require_in:
+      - file: bareos_password_file
+    {% endif %}
 
 {% if bc_config != {} %}
 bareos_bconsole_cfg_file:

--- a/bareos/director.sls
+++ b/bareos/director.sls
@@ -20,6 +20,10 @@ include:
     - require:
       - pkgrepo: bareos_repo
     {% endif %}
+    {% if salt['pillar.get']('bareos:generate_unique_password', False) %}
+    - require_in:
+      - file: bareos_password_file
+    {% endif %}
 {% endfor %}
 
 install_director_plugins:

--- a/bareos/filedaemon.sls
+++ b/bareos/filedaemon.sls
@@ -18,6 +18,10 @@ install_fd_package:
     - require:
       - pkgrepo: bareos_repo
     {% endif %}
+    {% if salt['pillar.get']('bareos:generate_unique_password', False) %}
+    - require_in:
+      - file: bareos_password_file
+    {% endif %}
 
 install_fd_plugins:
   pkg.installed:

--- a/bareos/storage.sls
+++ b/bareos/storage.sls
@@ -18,6 +18,10 @@ install_storage_package:
     - require:
       - pkgrepo: bareos_repo
     {% endif %}
+    {% if salt['pillar.get']('bareos:generate_unique_password', False) %}
+    - require_in:
+      - file: bareos_password_file
+    {% endif %}
 
 install_storage_plugins:
   pkg.installed:

--- a/bareos/traymonitor.sls
+++ b/bareos/traymonitor.sls
@@ -18,6 +18,10 @@ install_traymon_package:
     - require:
       - pkgrepo: bareos_repo
     {% endif %}
+    {% if salt['pillar.get']('bareos:generate_unique_password', False) %}
+    - require_in:
+      - file: bareos_password_file
+    {% endif %}
 
 
 {% if tm_config != {} %}


### PR DESCRIPTION
This is to avoid trying to deploy the config file before the
pkg is installed and it creates the user and group