### PR TITLE
Fix for debian repo for latest version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 bareos formula
 ==============
 
+0.1.0 (2019-02-07)
+- Fix debian repository for latest version (18.2)
+  * Use key_url to get GPG key from repo instead of keyserver
+
 0.0.5 (2018-07-11)
 - New upstream version
   * Added travis support

--- a/bareos/defaults.yaml
+++ b/bareos/defaults.yaml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 bareos:
-  version: 17.2.4-9.1*
+  version: 18.2.5-139.1
   config_dir: /etc/bareos
   default_password: default_bareos_formula_password
   system_user: bareos

--- a/bareos/defaults.yaml
+++ b/bareos/defaults.yaml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 bareos:
-  version: 18.2.5-139.1
+  version: 18.2.5-139.1*
   config_dir: /etc/bareos
   default_password: default_bareos_formula_password
   system_user: bareos

--- a/bareos/osfamilymap.yaml
+++ b/bareos/osfamilymap.yaml
@@ -1,6 +1,7 @@
 Debian:
   repo:
     file: /etc/apt/sources.list.d/bareos.list
+    use_key_url: true
 RedHat:
   repo:
     file: /etc/yum.repos.d/bareos.repo

--- a/bareos/repo.sls
+++ b/bareos/repo.sls
@@ -19,8 +19,12 @@ bareos_repo:
     - humanname: {{ bareos.repo.humanname }} - {{ bareos.repo.version }}
     - name: deb {{ url }} ./
     - file: {{ bareos.repo.file }}
+    {% if bareos.repo.key_url is defined -%}
+    - key_url: {{ url }}/Release.key
+    {% else -%}
     - keyid: {{ bareos.repo.keyid }}
     - keyserver: {{ bareos.repo.keyserver }}
+    {% endif -%}
 
 {%- elif grains.os_family == 'RedHat' %}
 bareos_repo:

--- a/bareos/repo.sls
+++ b/bareos/repo.sls
@@ -19,7 +19,7 @@ bareos_repo:
     - humanname: {{ bareos.repo.humanname }} - {{ bareos.repo.version }}
     - name: deb {{ url }} ./
     - file: {{ bareos.repo.file }}
-    {% if bareos.repo.key_url is defined -%}
+    {% if bareos.repo.use_key_url is defined -%}
     - key_url: {{ url }}/Release.key
     {% else -%}
     - keyid: {{ bareos.repo.keyid }}

--- a/pillar.example
+++ b/pillar.example
@@ -23,6 +23,8 @@ bareos:
     keyserver: keyserver.ubuntu.com
     humanname: Bareos Official Repository
     version: latest
+    # to get key from Release.key file in repo, keyid and keyserver will be ignored
+    use_key_url: true
 
   director:
     pkg: bareos-director

--- a/test/integration/bareos-postgresql/bareos-postgresql_spec.rb
+++ b/test/integration/bareos-postgresql/bareos-postgresql_spec.rb
@@ -28,7 +28,7 @@ control 'Bareos packages' do
   %w(bareos-director bareos-database-postgresql).each do |pkg|
     describe package(pkg) do
       it { should be_installed }
-      its('version') { should match '17.2.4-9.1' }
+      its('version') { should match '18.2.5-139.1' }
     end
   end
 end


### PR DESCRIPTION
I'm trying to install latest version (18.2) and repo is signed with key A7862CEE, but I can't find it in a keyserver. This change allows to define key_url: true to download key from repo_url/Release.key