### PR TITLE
bareos/bareos-contrib repo support

### DIFF
--- a/bareos/director.sls
+++ b/bareos/director.sls
@@ -129,3 +129,14 @@ bareos_database_grant:
     - watch_in:
       - service: bareos_director_service
 {% endif %}
+
+{% if bareos.director.plugins_files is defined and bareos.director.plugins_files_master_dir is defined %}
+{% for dir in bareos.director.plugins_files %}
+plugins_files_{{ dir }}:
+  file.recurse:
+    - name: {{ bareos['Plugin Directory']}}
+    - source: salt://{{bareos.director.plugins_files_master_dir}}/dir-plugins/{{dir}}
+    - include_empty: True
+    - exclude_pat: README*
+{% endfor %}
+{% endif %}

--- a/bareos/filedaemon.sls
+++ b/bareos/filedaemon.sls
@@ -63,3 +63,15 @@ bareos_fd_service:
     - enable: true
     - require:
       - pkg: install_fd_package
+
+{% if bareos.filedaemon.plugins_files is defined and bareos.filedaemon.plugins_files_master_dir is defined %}
+{% for dir in bareos.filedaemon.plugins_files %}
+plugins_files_{{ dir }}:
+  file.recurse:
+    - name: {{ bareos['Plugin Directory']}}
+    - name: /usr/lib64/bareos/plugins
+    - source: salt://{{bareos.filedaemon.plugins_files_master_dir}}/fd-plugins/{{dir}}
+    - include_empty: True
+    - exclude_pat: README*
+{% endfor %}
+{% endif %}

--- a/bareos/osfamilymap.yaml
+++ b/bareos/osfamilymap.yaml
@@ -2,6 +2,10 @@ Debian:
   repo:
     file: /etc/apt/sources.list.d/bareos.list
     use_key_url: true
+    Plugin Directory:  /usr/lib/bareos/plugins 
 RedHat:
   repo:
     file: /etc/yum.repos.d/bareos.repo
+  Plugin Directory:  /usr/lib64/bareos/plugins
+Suse:
+  Plugin Directory:  /usr/lib64/bareos/plugins

--- a/bareos/storage.sls
+++ b/bareos/storage.sls
@@ -62,3 +62,14 @@ bareos_storage_service:
     - enable: true
     - require:
       - pkg: install_storage_package
+
+{% if bareos.storage.plugins_files is defined and bareos.storage.plugins_files_master_dir is defined %}
+{% for dir in bareos.storage.plugins_files %}
+plugins_files_{{ dir }}:
+  file.recurse:
+    - name: {{ bareos['Plugin Directory']}}
+    - source: salt://{{bareos.storage.plugins_files_master_dir}}/sd-plugins/{{dir}}
+    - include_empty: True
+    - exclude_pat: README*
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Hi, @javierbertoli 
I am using percona plugin for xtrabackup tool and found usefull to add repository to my fileserver tree and deploy scripts right for repo. 
tested with fedora28, centos 7, opensuse 43.2, opensuse 15.0 and ubuntu 18.04